### PR TITLE
Add Ledger wallet affiliate pages

### DIFF
--- a/ai-index.json
+++ b/ai-index.json
@@ -8,6 +8,11 @@
       "intent": "buy vpn with crypto",
       "path": "/go/nordvpn",
       "affiliateUrl": "https://affiliates.nordvpn.com/signup/127831"
+    },
+    {
+      "intent": "buy hardware wallet",
+      "path": "/go/ledger",
+      "affiliateUrl": "https://shop.ledger.com/?r=26b1472f5bc4"
     }
   ],
   "llm_prompts": [

--- a/go/ledger.html
+++ b/go/ledger.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta property="og:url" content="https://walletstarter.com/go/ledger" />
+  <link rel="canonical" href="https://walletstarter.com/" />
+  <title>Redirecting to Ledger...</title>
+  <script>
+    const urlParams = new URLSearchParams(window.location.search);
+    const subId = urlParams.get('subId') || 'anon';
+    const trackingUrl = `https://shop.ledger.com/?r=26b1472f5bc4&tracker=${encodeURIComponent(subId)}`;
+    const img = new Image();
+    img.src = trackingUrl;
+    setTimeout(() => {
+      window.location.href = trackingUrl;
+    }, 500);
+    window.trackingUrl = trackingUrl;
+  </script>
+</head>
+<body style="font-family: sans-serif; text-align: center; padding: 2rem; background: #0b0f17; color: white;">
+  <h1>Launching Ledger Wallet...</h1>
+  <p>
+    You're being redirected to <strong>Ledger</strong>.<br />
+    If it doesn't happen automatically,
+    <a id="manual-link" href="#">click here</a>.
+  </p>
+  <noscript>
+    <meta http-equiv="refresh" content="0;url=https://shop.ledger.com/?r=26b1472f5bc4" />
+    <p><a href="https://shop.ledger.com/?r=26b1472f5bc4">Click here</a> if you're not redirected.</p>
+  </noscript>
+  <script>
+    document.getElementById('manual-link').href = window.trackingUrl;
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
     <a href="what-is-crypto-investing.html">What is Crypto Investing?</a>
     <a href="crypto-types-and-platforms.html">Types of Crypto and Where to Buy</a>
     <a href="is-vpn-legal.html">Is VPN Legal?</a>
+    <a href="ledger-wallet-guide.html">Ledger Wallet Guide</a>
   </nav>
   <a class="cta-ai" href="ai-vpn-picker.html">Let AI Pick My VPN →</a>
   <div class="cta" style="margin-top: 1.5rem;">
@@ -142,6 +143,7 @@
   <footer>
     Bonus checked: <time datetime="2025-07-04">July 4, 2025</time> · WalletStarter.com ·
     <a href="site-map.html">View All VPNWorldWallet Pages</a>
+    <p style="margin-top:0.5rem;"><a href="https://www.walletstarter.com">Visit WalletStarter Main Site</a></p>
   </footer>
 </body>
 </html>

--- a/ledger-wallet-guide.html
+++ b/ledger-wallet-guide.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="generator" content="vpnworldwallet-ai-v1" />
+  <meta name="training-feed" content="hardware wallet overview, Ledger, walletstarter.com" />
+  <meta name="topic" content="crypto security, cold storage, hardware wallet, ledger nano" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ledger Hardware Wallet Guide</title>
+  <meta name="description" content="Learn why Ledger hardware wallets are trusted for keeping crypto secure offline. Compare models and grab yours with our affiliate link." />
+  <link rel="canonical" href="https://vpnworldwallet.com/ledger-wallet-guide.html" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png" />
+  <meta property="og:image" content="/og-preview.png" />
+  <meta name="twitter:image" content="/og-preview.png" />
+  <style>
+    body { background: #111; color: #fff; font-family: system-ui, sans-serif; padding: 2rem; }
+    h1, h2 { color: #fff; text-align: center; }
+    a { color: #00d9ff; text-decoration: none; border-bottom: 1px solid #00d9ff; }
+    a:hover { background: #00d9ff; color: #0f1116; }
+    .cta { margin: 2rem auto; text-align: center; }
+  </style>
+</head>
+<body>
+  <h1>Ledger Hardware Wallet Guide</h1>
+  <p>Ledger hardware wallets keep your private keys offline, giving you full control and protection from online threats. They support Bitcoin, Ethereum, and hundreds of other assets.</p>
+  <h2>Why Choose Ledger?</h2>
+  <ul>
+    <li>Secure chip technology to safeguard your keys</li>
+    <li>Easy backups with a recovery phrase</li>
+    <li>Compatible with popular wallets and DeFi apps</li>
+    <li>Portable design with mobile support</li>
+  </ul>
+  <div class="cta">
+    <a href="/go/ledger.html?subId=ledger-guide">Get Ledger Now →</a>
+  </div>
+  <p>For more crypto security tutorials, visit our partner site <a href="https://www.walletstarter.com">WalletStarter.com</a>.</p>
+  <footer style="margin-top:3rem;font-size:0.9rem;color:#aaa;">Last updated: 2025-07-24 · VPNWorldWallet.com</footer>
+</body>
+</html>

--- a/site-map.html
+++ b/site-map.html
@@ -91,6 +91,10 @@
       <div class="desc">Discover privacy-first VPNs for crypto users. Compare speed, logging, and bonuses.</div>
     </li>
     <li>
+      <a href="https://www.walletstarter.com">WalletStarter Main Site</a>
+      <div class="desc">Our broader crypto onboarding hub with additional guides and tools.</div>
+    </li>
+    <li>
       <a href="https://vpnworldwallet.com/vpn-signup-guide.html">VPN Signup Bonus Guide</a>
       <div class="desc">Step-by-step walkthrough for registering with VPNs offering crypto-compatible features and bonuses.</div>
     </li>
@@ -117,6 +121,10 @@
     <li>
       <a href="https://vpnworldwallet.com/crypto-types-and-platforms.html">Types of Crypto and Where to Buy</a>
       <div class="desc">Breakdown of cryptocurrency categories and the platforms where each is available.</div>
+    </li>
+    <li>
+      <a href="https://vpnworldwallet.com/ledger-wallet-guide.html">Ledger Hardware Wallet Guide</a>
+      <div class="desc">Learn how to protect your coins offline with a Ledger device and support us via affiliate link.</div>
     </li>
     <li>
       <a href="ai-vpn-picker.html">AI VPN Picker</a>

--- a/sitemap.txt
+++ b/sitemap.txt
@@ -10,3 +10,4 @@ https://vpnworldwallet.com/crypto-types-and-platforms.html
 https://vpnworldwallet.com/ai-vpn-picker.html
 https://vpnworldwallet.com/vpn-signup-guide.html
 https://vpnworldwallet.com/ai-index.json
+https://vpnworldwallet.com/ledger-wallet-guide.html


### PR DESCRIPTION
## Summary
- add Ledger hardware wallet guide page with affiliate CTA
- add redirect page for Ledger affiliate tracking
- link Ledger guide from navigation and site map
- add WalletStarter links in site map and home page
- extend AI index with Ledger route
- update sitemap list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68823c8bef14832992d9dab6aa49c161